### PR TITLE
doc: update getResponse API

### DIFF
--- a/apps/docs/content/docs/frameworks/vue.mdx
+++ b/apps/docs/content/docs/frameworks/vue.mdx
@@ -42,7 +42,7 @@ Vue uses template refs or the `useCaptcha` composable for reactive access to the
 import { useCaptcha } from "@better-captcha/vue";
 import { ReCaptcha, type ReCaptchaHandle } from "@better-captcha/vue/provider/recaptcha";
 
-const { captchaRef, handle, execute, reset } = useCaptcha<ReCaptchaHandle>();
+const { captchaRef, execute, reset, getResponse } = useCaptcha<ReCaptchaHandle>();
 
 const recaptchaRef = captchaRef;
 
@@ -51,7 +51,7 @@ const onReady = (readyHandle: ReCaptchaHandle) => {
 };
 
 const logResponse = () => {
-  console.log(handle.value?.getResponse());
+  console.log(getResponse());
 };
 </script>
 ```


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Vue `useCaptcha` composable usage documentation. The composable's return object now includes `getResponse` and no longer exposes `handle`. Call sites updated to reflect the new API structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->